### PR TITLE
Add cmd-id.muf

### DIFF
--- a/cmd-id.muf
+++ b/cmd-id.muf
@@ -16,6 +16,9 @@ $version 1.1
 $note A simple object describer.
 
 $include $lib/bits
+$ifnlib $lib/stoplights
+    $def .tellgood .tell
+$endif
 
 : rtn-getType  ( db -- str }  Returns a string identifying the object type of db. )
     dup ok? not if pop "garbage"  exit then  ( db )

--- a/cmd-id.muf
+++ b/cmd-id.muf
@@ -1,0 +1,34 @@
+@program cmd-id.muf
+1 1000 d
+i
+( cmd-id.muf by Natasha@HLM
+  A simple object describer.
+)
+$include $lib/bits
+$include $lib/syvel-funcs
+$def .color-unparseobj obj-color
+: main  ( str -- }  Print out the unparseobj for the given string. )
+	dup strip "#help" stringcmp not if "_help" rtn-dohelp exit then  ( str )
+
+	dup if match else pop me @ then  ( db )
+	dup obj-color  ( db str )
+	over ok? if  ( db str )
+		over owner swap "%s     Owner: %D" fmtstring  ( db str )
+		over exit? if  ( db str )
+			over getlink obj-color swap "%s     Link: %s" fmtstring  ( db str )
+		then  ( db str )
+	then  ( db str )
+	.tellgood pop  (  )
+;
+.
+c
+q
+@act id;db=#0
+@link id=cmd-id
+lsedit cmd-id=_help
+.del 1 $
+id <object>
+db <object>
+ 
+Displays the name and dbref for the given object.
+.end

--- a/cmd-id.muf
+++ b/cmd-id.muf
@@ -3,7 +3,17 @@
 i
 ( cmd-id.muf by Natasha@HLM
   A simple object describer.
+
+  Copyright 2003 Natasha Snunkmeox. Copyright 2003 Here Lie Monsters.
+  "@view $box/mit" for license information.
+
+  Version history
+  1.0, 25 Oct 2003: First version.
 )
+$author Natasha Snunkmeox <natmeox@neologasm.org>
+$version 1.0
+$note A simple object describer.
+
 $include $lib/bits
 $include $lib/syvel-funcs
 $def .color-unparseobj obj-color

--- a/cmd-id.muf
+++ b/cmd-id.muf
@@ -8,17 +8,17 @@ $include $lib/bits
 $include $lib/syvel-funcs
 $def .color-unparseobj obj-color
 : main  ( str -- }  Print out the unparseobj for the given string. )
-	dup strip "#help" stringcmp not if "_help" rtn-dohelp exit then  ( str )
+    dup strip "#help" stringcmp not if "_help" rtn-dohelp exit then  ( str )
 
-	dup if match else pop me @ then  ( db )
-	dup obj-color  ( db str )
-	over ok? if  ( db str )
-		over owner swap "%s     Owner: %D" fmtstring  ( db str )
-		over exit? if  ( db str )
-			over getlink obj-color swap "%s     Link: %s" fmtstring  ( db str )
-		then  ( db str )
-	then  ( db str )
-	.tellgood pop  (  )
+    dup if match else pop me @ then  ( db )
+    dup obj-color  ( db str )
+    over ok? if  ( db str )
+        over owner swap "%s     Owner: %D" fmtstring  ( db str )
+        over exit? if  ( db str )
+            over getlink obj-color swap "%s     Link: %s" fmtstring  ( db str )
+        then  ( db str )
+    then  ( db str )
+    .tellgood pop  (  )
 ;
 .
 c

--- a/cmd-id.muf
+++ b/cmd-id.muf
@@ -4,19 +4,37 @@ i
 ( cmd-id.muf by Natasha@HLM
   A simple object describer.
 
-  Copyright 2003 Natasha Snunkmeox. Copyright 2003 Here Lie Monsters.
+  Copyright 2003-2019 Natasha Snunkmeox. Copyright 2003-2019 Here Lie Monsters.
   "@view $box/mit" for license information.
 
   Version history
   1.0, 25 Oct 2003: First version.
+  1.1, 26 Jan 2019: Vendorized the obj-color word for portability.
 )
 $author Natasha Snunkmeox <natmeox@neologasm.org>
-$version 1.0
+$version 1.1
 $note A simple object describer.
 
 $include $lib/bits
-$include $lib/syvel-funcs
-$def .color-unparseobj obj-color
+
+: rtn-getType  ( db -- str }  Returns a string identifying the object type of db. )
+    dup ok? not if pop "garbage"  exit then  ( db )
+    dup player? if pop "player"   exit then
+    dup program? if pop "program" exit then
+    dup exit?    if pop "exit"    exit then
+    dup room?    if pop "room"    exit then
+    pop "thing"
+;
+
+: obj-color  ( db -- str )
+    dup ok? if  ( db )
+        dup unparseobj over name strlen strcut  ( db strName strData )
+        "bold,yellow" textattr strcat  ( db str )
+    else "<unknown>" then  ( db str )
+    prog "_obj-color/" 4 rotate rtn-getType strcat getpropstr  ( str strColor )
+    textattr  ( str )
+;
+
 : main  ( str -- }  Print out the unparseobj for the given string. )
     dup strip "#help" stringcmp not if "_help" rtn-dohelp exit then  ( str )
 
@@ -30,6 +48,8 @@ $def .color-unparseobj obj-color
     then  ( db str )
     .tellgood pop  (  )
 ;
+
+PUBLIC obj-color
 .
 c
 q
@@ -42,3 +62,9 @@ db <object>
  
 Displays the name and dbref for the given object.
 .end
+@set cmd-id=_obj-color/garbage:bold,black
+@set cmd-id=_obj-color/player:bold,green
+@set cmd-id=_obj-color/program:bold,red
+@set cmd-id=_obj-color/exit:bold,green
+@set cmd-id=_obj-color/room:bold,cyan
+@set cmd-id=_obj-color/thing:bold,magenta

--- a/lib-stoplights.muf
+++ b/lib-stoplights.muf
@@ -1,0 +1,72 @@
+@program lib-stoplights.muf
+1 9999 d
+i
+( lib-stoplights.muf by Natasha@HLM
+  Clearly label success and error responses from MUF programs.
+
+  Copyright 2019 Natasha Snunkmeox. Copyright 2019 Here Lie Monsters.
+  "@view $box/mit" for license information.
+
+
+  This library signals the presence of several MUF macros for clearly labeling
+  command output as a success, error or warning. The original version for HLM
+  defines these as:
+
+      [%] in green: a good success
+      [?] in yellow: a warning
+      ]![ in red: a bad error
+
+  Feel free to customize them for your MUCK when porting!
+
+  You can use the `$iflib` directives in your program to determine if these
+  macros are available:
+
+      $ifnlib $lib/stoplights
+          $def .tellgood .tell
+          $def .tellwarn .tell
+          $def .tellbad  .tell
+      $endif
+
+  The distributable version of this library defines these macros:
+
+  .tell  { str -- }
+  Display `str` to the current user. {This is a common macro most MUCKs already
+  have.}
+
+  .str-good  { -- str }
+  .str-warn  { -- str }
+  .str-bad   { -- str }
+  Produce one of three "stoplights": a color coded string suitable for
+  prepending onto a message to label it as a success, error or warning
+  respectively.
+
+  .notifygood  { db str -- }
+  .notifywarn  { db str -- }
+  .notifybad   { db str -- }
+  As with `notify`, display `str` to `db`, but marked with the appropriate
+  stoplight.
+
+  .tellgood  { str -- }
+  .tellwarn  { str -- }
+  .tellbad   { str -- }
+  As with the common `.tell` macro, display `str` to the current user, but
+  marked with the appropriate stoplight.
+
+)
+: main ;
+.
+c
+def str-good "\[[32m[\[[1;32m%\[[0;32m]\[[0m "
+def str-bad "\[[31m]\[[1;31m!\[[0;31m[\[[0m "
+def str-warn "\[[30m[\[[1;30m?\[[0;30m[\[[0m "
+def notifybad .str-bad swap strcat notify
+def notifygood .str-good swap strcat notify
+def notifywarn .str-warn swap strcat notify
+def tellbad .str-bad swap strcat .tell
+def tellgood .str-good swap strcat .tell
+def tellwarn .str-warn swap strcat .tell
+def tell "me" match swap notify
+q
+@set lib-stoplights.muf=v
+@set lib-stoplights.muf=!m
+@register lib-stoplights.muf=lib/stoplights


### PR DESCRIPTION
Someone asked about HLM's `id` command, which I seem not to have put in here. It seemed prudent to remove a dependency rather than include this other one-off library, so I vendorized this `obj-color` word into the command itself.