### PR TITLE
Simplify installing the lib/bits library

### DIFF
--- a/lib-bits.muf
+++ b/lib-bits.muf
@@ -91,14 +91,13 @@ i
                     Reimplemented rtn-pad* using fmtstring {as modern
                     $lib/strings does anyway}.
                     Removed str-good & str-bad stoplight words.
+                    Finds ourselves whether rtn-dohelp can parse MPI
+                    rather than having to be configured.
 )
 $author Natasha Snunkmeox <natmeox@neologasm.org>
 $version 2.0
 $lib-version 2.0
 $note Common code helpers for hlm-suite programs.
-
-( Comment this line out if you are not able to give this library an M3 bit. )
-$def HAVE_M3 ()
 
 
 $include $lib/case
@@ -201,16 +200,17 @@ lvar v_addy
 ;
 
 lvar v_dir
+lvar v_loadprop
+: loadprop-parse  ( db str -- str )  "(#help)" 1 parseprop ;
+: loadprop-get    ( db str -- str )  getpropstr ;
 : rtn-dohelp  ( str -- }  Displays help on the calling program in lsedit list str. )
+    prog mlevel 3 >= if 'loadprop-parse else 'loadprop-get then v_loadprop !
+
     "#" strcat dup "/" strcat v_dir !  ( strProp )
     caller swap getpropstr atoi 1  ( intLines intCur )
     begin over over >= while  ( intLines intCur )
         caller v_dir @ 3 pick intostr strcat  ( intLines intCur dbClr strLineProp )
-$ifdef HAVE_M3
-        "(#help)" 1 parseprop  ( intLines intCur strLine )
-$else
-        getpropstr  ( intLines intCur strLine )
-$endif
+        v_loadprop @ execute  ( intLines intCur strLine )
         .tell  ( intLines intCur )
     1 + repeat pop pop  (  )
 ;

--- a/lib-bits.muf
+++ b/lib-bits.muf
@@ -88,13 +88,13 @@ i
   1.0, 30 Aug 2002: Possibly something like the first version.
   2.0, 26 Jan 2019: Required Fuzzball 6.
                     Reimplemented rtn-othersort using arrays.
+                    Reimplemented rtn-pad* using fmtstring {as modern
+                    $lib/strings does anyway}.
 )
 $author Natasha Snunkmeox <natmeox@neologasm.org>
 $version 2.0
 $lib-version 2.0
 $note Common code helpers for hlm-suite programs.
-
-$def ref_lib-strings #179
 
 ( Comment this line out if you are not able to give this library an M3 bit. )
 $def HAVE_M3 ()
@@ -109,21 +109,21 @@ $include $lib/case
     dup 3 pick strlen < if  ( str int )
         strcut pop  ( str' )
     else
-        ref_lib-strings "STRleft" call  ( str' )
+        "%-*s" fmtstring  ( str' )
     then  ( str' )
 ;
 : rtn-padright  ( str int -- str' )
     dup 3 pick strlen < if  ( str int )
         strcut pop  ( str' )
     else
-        ref_lib-strings "STRright" call  ( str' )
+        "%*s" fmtstring  ( str' )
     then  ( str' )
 ;
 : rtn-padcenter  ( str int -- str' )
     dup 3 pick strlen < if  ( str int )
         strcut pop  ( str' )
     else
-        ref_lib-strings "STRcenter" call  ( str' )
+        "%|*s" fmtstring  ( str' )
     then  ( str' )
 ;
 

--- a/lib-bits.muf
+++ b/lib-bits.muf
@@ -83,7 +83,15 @@ i
   long ago that was. Algorithm taken from SC-Track Roundup's Date.py:Interval
   object.
 
+
+  Version history
+  1.0, 30 Aug 2002: Possibly something like the first version.
+  2.0, 26 Jan 2019: Require Fuzzball 6.
 )
+$author Natasha Snunkmeox <natmeox@neologasm.org>
+$version 2.0
+$lib-version 2.0
+$note Common code helpers for hlm-suite programs.
 
 $def ref_lib-strings #179
 
@@ -92,9 +100,6 @@ $def HAVE_M3 ()
 
 ( Uncomment this line to use $lib/edit for sorting, rather than the built-in method that requires an M3. )
 ($def USE_LIB_EDIT ()
-
-( Uncomment this line if you're on a Fuzzball 6 MUCK and can use the Fuzzball 6 words. )
-$def fb6 ()
 
 ( Uncomment if the MUCK doesn't have standard stoplights. )
 $undef OFFER_STOPLIGHTS
@@ -315,7 +320,6 @@ $else
 $endif
 ;
 
-$ifdef fb6
 : rtn-commas  ( arr -- db )
     dup array_count 1 = if  ( arr )
         dup array_first array_getitem name  ( str )
@@ -329,7 +333,6 @@ $ifdef fb6
         " and " strcat swap name strcat  ( str )
     then  ( str )
 ;
-$endif
 
 : rtn-rtimestr  ( int -- str )
     dup case  ( intSince )
@@ -371,10 +374,8 @@ PUBLIC rtn-dohelp
 PUBLIC rtn-dispatch
 PUBLIC rtn-match
 PUBLIC rtn-othersort
-$ifdef fb6
 PUBLIC rtn-commas
 PUBLIC rtn-rtimestr
-$endif
 $ifdef OFFER_STOPLIGHTS
 PUBLIC str-good
 PUBLIC str-bad

--- a/lib-bits.muf
+++ b/lib-bits.muf
@@ -90,6 +90,7 @@ i
                     Reimplemented rtn-othersort using arrays.
                     Reimplemented rtn-pad* using fmtstring {as modern
                     $lib/strings does anyway}.
+                    Removed str-good & str-bad stoplight words.
 )
 $author Natasha Snunkmeox <natmeox@neologasm.org>
 $version 2.0
@@ -98,9 +99,6 @@ $note Common code helpers for hlm-suite programs.
 
 ( Comment this line out if you are not able to give this library an M3 bit. )
 $def HAVE_M3 ()
-
-( Uncomment if the MUCK doesn't have standard stoplights. )
-$undef OFFER_STOPLIGHTS
 
 
 $include $lib/case
@@ -300,11 +298,6 @@ lvar v_addy
     endcase  ( str )
 ;
 
-$ifdef OFFER_STOPLIGHTS
-: str-good "[%] " ;
-: str-bad "]%[ " ;
-$endif
-
 : main 1 pop ;
 PUBLIC rtn-padleft
 PUBLIC rtn-padright
@@ -318,10 +311,6 @@ PUBLIC rtn-match
 PUBLIC rtn-othersort
 PUBLIC rtn-commas
 PUBLIC rtn-rtimestr
-$ifdef OFFER_STOPLIGHTS
-PUBLIC str-good
-PUBLIC str-bad
-$endif
 .
 c
 q


### PR DESCRIPTION
lib/bits had a bunch of silly dependencies that we can remove if we assume we're on Fuzzball 6.

Since that's technically backwards incompatible, this [bumps the version to 2.0](https://semver.org).