### PR TITLE
Add $libdefs for lib/bits functions

### DIFF
--- a/lib-bits.muf
+++ b/lib-bits.muf
@@ -311,6 +311,19 @@ PUBLIC rtn-match
 PUBLIC rtn-othersort
 PUBLIC rtn-commas
 PUBLIC rtn-rtimestr
+
+$libdef rtn-padleft
+$libdef rtn-padright
+$libdef rtn-padcenter
+$libdef rtn-substpct
+$libdef rtn-1explode
+$libdef rtn-substfirst
+$libdef rtn-dohelp
+$libdef rtn-dispatch
+$libdef rtn-match
+$libdef rtn-othersort
+$libdef rtn-commas
+$libdef rtn-rtimestr
 .
 c
 q

--- a/lib-bits.muf
+++ b/lib-bits.muf
@@ -93,6 +93,8 @@ i
                     Removed str-good & str-bad stoplight words.
                     Finds ourselves whether rtn-dohelp can parse MPI
                     rather than having to be configured.
+                    Made $lib/case optional, as Fuzzball 7 provides
+                    those words without a library.
 )
 $author Natasha Snunkmeox <natmeox@neologasm.org>
 $version 2.0
@@ -100,7 +102,10 @@ $lib-version 2.0
 $note Common code helpers for hlm-suite programs.
 
 
-$include $lib/case
+( Fuzzball 7 has case primitives, so the library is not required. )
+$iflib $lib/case
+    $include $lib/case
+$endif
 
 : rtn-padleft  ( str int -- str' )
     dup 3 pick strlen < if  ( str int )


### PR DESCRIPTION
Without these, the `lib-bits.muf` script doesn't produce a working `$lib/bits`, where its `PUBLIC` words are callable by their names.

This resolves #3. @nyanster also mentioned there that the `case` structure is available out of the box in Fuzzball 7 MUF, so let's not require it, in case that works.